### PR TITLE
adding support to compile less files inside a plugin

### DIFF
--- a/LesscssResourcesGrailsPlugin.groovy
+++ b/LesscssResourcesGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class LesscssResourcesGrailsPlugin {
     // the plugin version
-    def version = "0.6"
+    def version = "0.6.1-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.5 > *"
     // the other plugins this plugin depends on

--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -67,13 +67,6 @@ class LesscssResourceMapper {
             if(resourceFile.exists()){
                 return resourceFile
             }
-
-            for(directory in GrailsPluginUtils.getPluginBaseDirectories()){
-                resourceFile = new File(directory + '/' + pluginName + '/' + GrailsResourceUtils.WEB_APP_DIR + '/' + resourcePath)
-                if(resourceFile.exists()){
-                    return resourceFile
-                }
-            }
         }
 
         return new File(GrailsResourceUtils.WEB_APP_DIR + sourcePath)

--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -2,6 +2,7 @@ import com.asual.lesscss.LessEngine
 import com.asual.lesscss.LessException
 import org.grails.plugin.resource.mapper.MapperPhase
 import org.codehaus.groovy.grails.plugins.GrailsPluginUtils
+import grails.util.PluginBuildSettings
 
 /**
  * @author Paul Fairless
@@ -57,8 +58,15 @@ class LesscssResourceMapper {
     private File getOriginalFileSystemFile(String sourcePath) {
         def resourceFile
         if(isPlugin(sourcePath)){
-            def pluginName = getPluginFullName(sourcePath)
-            def resourcePath = getResourceRelativePath(pluginName, sourcePath)
+            def pluginFullName = getPluginFullName(sourcePath)
+            def resourcePath = getResourceRelativePath(pluginFullName, sourcePath)
+
+            def ourPluginInfo = GrailsPluginUtils.getPluginInfos().find{pluginInfo -> pluginFullName.contains(pluginInfo.name)}
+            resourceFile = new File(ourPluginInfo.pluginDir.path + '/' + GrailsResourceUtils.WEB_APP_DIR + '/' + resourcePath)
+
+            if(resourceFile.exists()){
+                return resourceFile
+            }
 
             for(directory in GrailsPluginUtils.getPluginBaseDirectories()){
                 resourceFile = new File(directory + '/' + pluginName + '/' + GrailsResourceUtils.WEB_APP_DIR + '/' + resourcePath)


### PR DESCRIPTION
Hi Paul,

Thanks for your contribution this plugin made our work possible, 

we are working using a plugin oriented architecture where we have a core plugin which provides common resources as templates, css, javascripts and images, the plugin works great when using it on the main application (the less files live on the main app) however it fails when the less files live in a plugin, because it can't work out the right path,

I have added support for this case, when you got a plugin that uses lesscss-resources that then is then installed on another application,

There is something dodgy that I don't like on code that I committed and it's the way that I used to find out whether the resource lives on a plugin I had to rely on the sourcePath, as far as I've seen the object ResourceMeta does not provide a pluginName property (the name of the plugin passed in the resource for instance "resource url:[dir:'css', file:'basic.less', plugin:'basic-core'], bundle:'bundle_style'") which would be ideal for this case,

Please check the changes and let me know your thoughts,
