### PR TITLE
Improve .less handling and compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+stacktrace.log
+target/*
+web-app/WEB-INF/tld/*
+

--- a/LesscssResourcesGrailsPlugin.groovy
+++ b/LesscssResourcesGrailsPlugin.groovy
@@ -1,3 +1,6 @@
+import org.grails.plugin.resource.ResourceService
+import org.grails.plugin.resource.ResourceTagLib
+
 class LesscssResourcesGrailsPlugin {
     // the plugin version
     def version = "0.6.1"
@@ -21,4 +24,16 @@ This plugin supports server-side compilation of .less CSS files to their .css co
 
     // URL to the plugin's documentation
     def documentation = "https://github.com/paulfairless/grails-lesscss-resources"
+
+    def doWithSpring = { ->
+        // monkey-patch ResourceService and ResourceTagLib to support .less files
+        ResourceService.DEFAULT_MODULE_SETTINGS['less'] = [
+            disposition: 'head' 
+        ]
+        ResourceTagLib.SUPPORTED_TYPES['less'] = [
+            type: "text/css", 
+            rel: 'stylesheet/less', 
+            media: 'screen, projection' 
+        ]
+    }
 }

--- a/test/functional/LesscssBundleSpec.groovy
+++ b/test/functional/LesscssBundleSpec.groovy
@@ -10,7 +10,7 @@ class LesscssBundleSpec extends GebSpec {
     }
     def "check lesscss rules rendered"(){
         when:
-            go('http://localhost:8080/lesscss-resources')
+            go('')
         then:
         $('h1').text() == 'Less Test'
         $('h1').jquery.css('color') == 'rgb(34, 34, 251)'


### PR DESCRIPTION
Hey Paul:

Thanks for your work on this plugin. It's been very useful.

In this pull request I improved the support for .less files from the resources plugin by "monkey-patching" ResourceService and ResourceTagLib. I'm sure this is not the ideal way, but since there's currently no direct support to add asset types in resources, this approach seemed the best option.

This brings the benefit of no longer needing to specify type and rel attributes in the resource declaration. Also, I added operation = "compile" to the mapper so it's now possible to exclude the execution of the engine via the option exclude: 'compile' in the resource declaration. And since the tag lib is patched, it'll render the <link> tag with the appropriate attributes.

The other change is compiling the less files from URLs instead of files. I was using version 0.6 and ran into problems when trying to deploy in a WAR (the mapper was not finding the source file). I think probably your fix in 0.6.1 might have solved the issue, but I didn't know about it until today. Anyway, since the solution I found is different, I'm sending it nevertheless. In any case, I think mine is a more general solution, in part because it uses the resources service to perform the path resolution.

The only complication is that in development mode the mapper wasn't working with resource reloads due to a problem with the class loader (somewhat related to http://jira.grails.org/browse/GRAILS-5592 ). Hence, I added a workaround by setting the context class loader before attempting to compile.

Regards,
Gustavo
