### PR TITLE
Better stack trace logging

### DIFF
--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -42,8 +42,7 @@ class LesscssResourceMapper implements GrailsApplicationAware {
                 resource.contentType = 'text/css'
                 resource.tagAttributes.rel = 'stylesheet'
             } catch (LessException e) {
-                log.error("error compiling less file: ${originalFile}")
-                e.printStackTrace()
+                log.error("error compiling less file: ${originalFile}", e)
             }
         }
     }


### PR DESCRIPTION
I think it is better to provide exception to logging framework that will handle it appropriately instead of directly printing it to output.
Actually in my configuration I cannot see this directly printed stack trace at all, that efectively leaves me in the dark when something goes wrong.
