### PR TITLE
Added Compress option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,14 @@ Note that the files to be imported are not part of the resources bundle, so any 
 
 
 See the <a href="http://www.grails.org/plugin/resources">Resources plugin</a> for more details on available configurations
+
+##Options##
+You can use the LessCSS engine to compress the output by adding this to your Config.groovy:
+
+    grails.lesscss.resources.compress = true
+
+By default the output is not compressed.
+
 ##Changelog##
 
 1.3.0 - Breaking Chnage - Asual LessCSS compiler has been replaced with <a href="https://github.com/marceloverdijk/lesscss-java">lesscss-java</a>

--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -20,6 +20,8 @@ class LesscssResourceMapper implements GrailsApplicationAware {
 
     def map(resource, config){
         LessCompiler lessCompiler = new LessCompiler()
+        boolean compress = grailsApplication.config.grails.lesscss.resources.compress ?: false
+        lessCompiler.setCompress(compress)
         File originalFile = resource.processedFile
         File input = getOriginalFileSystemFile(resource.sourceUrl);
         File target = new File(generateCompiledFileFromOriginal(originalFile.absolutePath))


### PR DESCRIPTION
Since the YUI and LessCSS plugins don't play nice, it would be convenient to be able to compress the Less output directly.

This patch allows for easily toggling the compress option within the `LessCompiler` class using

```
grails.lesscss.resources.compress  = true
```

in `Config.groovy`.
