### PR TITLE
Made the BuildConfig more generic and updated dependencies + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+*.iws
+*Db.properties
+*Db.script
+.settings
+stacktrace.log
+/*.zip
+/plugin.xml
+/*.log
+/*DB.*
+/cobertura.ser
+.DS_Store
+/target/
+/out/
+/web-app/plugins
+/web-app/WEB-INF/classes
+.link_to_grails_plugins
+/target-eclipse/

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -19,7 +19,7 @@ grails.project.dependency.resolution = {
         // from public Maven repositories
         //mavenLocal()
         mavenCentral()
-        grailsRepo "http://grails.org/plugins"
+        //grailsRepo "http://grails.org/plugins"
         //mavenRepo "http://snapshots.repository.codehaus.org"
         //mavenRepo "http://repository.codehaus.org"
         //mavenRepo "http://download.java.net/maven/2/"
@@ -35,7 +35,7 @@ grails.project.dependency.resolution = {
         test ('org.gmock:gmock:0.8.2') {
             export = false
         }
-        test("org.seleniumhq.selenium:selenium-firefox-driver:2.21.0") {
+        test("org.seleniumhq.selenium:selenium-firefox-driver:2.23.1") {
             exclude 'selenium-server'
             export = false
         }
@@ -50,17 +50,14 @@ grails.project.dependency.resolution = {
         compile (":resources:1.1.6") {
             export = false
         }
-        compile (":hibernate:2.0.0") {
+        compile (":hibernate:$grailsVersion") {
             export = false
         }
-        compile (":rest-client-builder:1.0.2") {
+        compile (":tomcat:$grailsVersion") {
             export = false
         }
-        compile (":tomcat:2.0.0") {
+        build (":release:latest.integration", ":rest-client-builder:latest.integration") {
             export = false
         }
-//        compile (":release:2.0.0") {
-//            export = false
-//        }
     }
 }


### PR DESCRIPTION
-make use of $grailsVersion and latest.integration (latest-release
should work to by now as grails-plugins moved to a maven-compatible
repository <- but I haven't checked yet)
-bumped selenium-firefox-driver dependency to latest version (2.23.1)
-commented explizit grailsRepo "http://grails.org/plugins" <- not needed
any longer
-declared release and rest-client-builder plugin dependencies in build
scope
-created a .gitignore file

---

BTW: I don't think the dependency to hibernate is needed, but I left it in BuildConfig.groovy for the moment
