### PR TITLE
Use the processed file instead of the original one

### DIFF
--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -1,3 +1,4 @@
+import org.apache.commons.io.FileUtils
 import org.grails.plugin.resource.mapper.MapperPhase
 
 /**
@@ -25,7 +26,8 @@ class LesscssResourceMapper implements GrailsApplicationAware {
             lessCompiler.setCompress(grailsApplication.config.grails?.resources?.mappers?.lesscss?.compress == true ?: false)
         }
         File originalFile = resource.processedFile
-        File input = getOriginalFileSystemFile(resource.sourceUrl);
+        File input = new File("${getOriginalFileSystemFile(resource.sourceUrl).absolutePath}.temp.less");
+	    FileUtils.copyFile(originalFile, input)
         File target = new File(generateCompiledFileFromOriginal(originalFile.absolutePath))
 
         if (log.debugEnabled) {
@@ -44,6 +46,8 @@ class LesscssResourceMapper implements GrailsApplicationAware {
 
         } catch (LessException e) {
             log.error("error compiling less file: ${originalFile}", e)
+        } finally {
+	        input.delete()
         }
 
     }


### PR DESCRIPTION
I'm currently writing a plugin (https://github.com/tscheinecker/grails-augmented-resources) which modifies the less files before they are compiled.
At the moment I have to include an very unpleaset step in which i save the new file to the original files location and set it as the new source, and therefor I not only pollute the workspace but I also break live reloading for that particular file.
To solve the issue I extended your resource mapper to just create a copy of the processed file where it expects it to be, compile it and delete it right afterwards.
With this change arbitrary changes can be made to the less files before they get compiled and live reloading still works as expected.
