### PR TITLE
Catch generic exceptions in LesscssResourceMapper

### DIFF
--- a/grails-app/resourceMappers/LesscssResourceMapper.groovy
+++ b/grails-app/resourceMappers/LesscssResourceMapper.groovy
@@ -44,6 +44,8 @@ class LesscssResourceMapper implements GrailsApplicationAware {
 
         } catch (LessException e) {
             log.error("error compiling less file: ${originalFile}", e)
+        } catch (Exception ex) {
+            log.error("error compiling less file: ${originalFile}", ex)
         }
 
     }


### PR DESCRIPTION
Catch generic exceptions in LesscssResourceMapper to help troubleshooting.
